### PR TITLE
no core dump

### DIFF
--- a/files/dns-forwarder.init
+++ b/files/dns-forwarder.init
@@ -31,9 +31,6 @@ start_instance() {
 	procd_set_param stderr 1
 	procd_set_param nice -5
 	procd_set_param limits nofile="65535 65535"
-	[ -e /proc/sys/kernel/core_pattern ] && {
-		procd_append_param limits core="unlimited"
-	}
 	procd_set_param command /usr/bin/dns-forwarder
 	append_parm $1 listen_addr "-b"
 	append_parm $1 listen_port "-p"


### PR DESCRIPTION
上次的 https://github.com/aa65535/openwrt-dns-forwarder/pull/24 添加的，好像不太必要